### PR TITLE
Allow backporting merge commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Backport Bot is a [JavaScript GitHub Action](https://help.github.com/en/articles/about-actions#javascript-actions) to backport a pull request by simply adding a label to it.
 
-It can backport [rebased and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits) pull requests with a single commit and [squashed and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) pull requests. It thus integrates well with [Autosquash](https://github.com/marketplace/actions/autosquash).
+It can backport [rebased and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#rebase-and-merge-your-pull-request-commits) pull requests with a single commit, [pull requests merged with a merge commit](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges) as well as [squashed and merged](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits) pull requests. It thus integrates well with [Autosquash](https://github.com/marketplace/actions/autosquash).
 
 This version even works on forked repositories!
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -104,7 +104,7 @@ const backportOnce = async ({
     await git("checkout", "-b", head);
     try {
       try {
-        await git("cherry-pick", "-n", commitToBackport);
+        await git("cherry-pick", "-m", "1", "-n", commitToBackport);
       } catch (error3) {
         warning(error3); // continue but warn
       }

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -104,7 +104,7 @@ const backportOnce = async ({
     await git("checkout", "-b", head);
     try {
       try {
-        await git("cherry-pick", "-m", "1", "-n", commitToBackport);
+        await git("cherry-pick", "-m1", "-n", commitToBackport);
       } catch (error3) {
         warning(error3); // continue but warn
       }


### PR DESCRIPTION
Specify `-m 1` on the `cherry-pick` operation to allow backporting merge commits.

Note: I think this improves the situation but I'm not completely 100% sure on possible side effects.

Fixes #38 